### PR TITLE
chore: Improves names of integration endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Deploy the charm and integrate it to a certificate requirer, and to a certificat
 
 ```bash
 juju deploy tls-constraints --channel beta
-juju integrate tls-constraints <TLS Certificates Requirer>
-juju integrate tls-constraints <TLS Certificates Provider>
+juju integrate tls-constraints:certificates-downstream <TLS Certificates Requirer>
+juju integrate tls-constraints:certificates-upstream <TLS Certificates Provider>
 ```
 
 ## Integrations

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,12 +14,12 @@ source: https://github.com/canonical/tls-constraints-operator
 issues: https://github.com/canonical/tls-constraints-operator/issues
 
 requires:
-  certificates-requires:
+  certificates-upstream:
     interface: tls-certificates
     limit: 1
 
 provides:
-  certificates-provides:
+  certificates-downstream:
     interface: tls-certificates
 
 assumes:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -18,6 +18,8 @@ TLS_PROVIDER_CHARM_NAME = "self-signed-certificates"
 TLS_REQUIRER_CHARM_NAME = "tls-certificates-requirer"
 TLS_REQUIRER1 = f"{TLS_REQUIRER_CHARM_NAME}1"
 TLS_REQUIRER2 = f"{TLS_REQUIRER_CHARM_NAME}2"
+RELATION_NAME_TO_TLS_REQUIRER = "certificates-downstream"
+RELATION_NAME_TO_TLS_PROVIDER = "certificates-upstream"
 
 
 @pytest.fixture(scope="module")
@@ -64,7 +66,7 @@ async def test_given_provider_is_related_then_status_is_active(
 ):
     assert ops_test.model
     await ops_test.model.add_relation(
-        relation1=f"{APPLICATION_NAME}:certificates-requires",
+        relation1=f"{APPLICATION_NAME}:{RELATION_NAME_TO_TLS_PROVIDER}",
         relation2=TLS_PROVIDER_CHARM_NAME,
     )
 
@@ -77,7 +79,7 @@ async def test_given_tls_requirer1_is_deployed_and_related_then_certificate_is_c
 ):
     assert ops_test.model
     await ops_test.model.add_relation(
-        relation1=f"{APPLICATION_NAME}:certificates-provides", relation2=TLS_REQUIRER1
+        relation1=f"{APPLICATION_NAME}:{RELATION_NAME_TO_TLS_REQUIRER}", relation2=TLS_REQUIRER1
     )
     await ops_test.model.wait_for_idle(
         apps=[TLS_REQUIRER1],
@@ -96,7 +98,7 @@ async def test_given_tls_requirer2_is_deployed_and_related_then_certificate_is_c
 ):
     assert ops_test.model
     await ops_test.model.add_relation(
-        relation1=f"{APPLICATION_NAME}:certificates-provides",
+        relation1=f"{APPLICATION_NAME}:{RELATION_NAME_TO_TLS_REQUIRER}",
         relation2=TLS_REQUIRER2,
     )
     await ops_test.model.wait_for_idle(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -14,8 +14,8 @@ from charms.tls_certificates_interface.v3.tls_certificates import (
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus
 
-PROVIDES_RELATION_NAME = "certificates-provides"
-REQUIRES_RELATION_NAME = "certificates-requires"
+RELATION_NAME_TO_TLS_REQUIRER = "certificates-downstream"
+RELATION_NAME_TO_TLS_PROVIDER = "certificates-upstream"
 
 
 def get_json_csr_list(csr: str = "test_csr", is_ca: bool = False):
@@ -351,7 +351,7 @@ class TestCharm(unittest.TestCase):
 
     def _integrate_provider(self) -> int:
         provider_relation_id = self.harness.add_relation(
-            relation_name=REQUIRES_RELATION_NAME,
+            relation_name=RELATION_NAME_TO_TLS_PROVIDER,
             remote_app="certificates-provider",
         )
         self.harness.add_relation_unit(
@@ -364,7 +364,7 @@ class TestCharm(unittest.TestCase):
         self, app_name: str = "certificates-requirer", unit_id: int = 0
     ) -> int:
         requirer_relation_id = self.harness.add_relation(
-            relation_name=PROVIDES_RELATION_NAME,
+            relation_name=RELATION_NAME_TO_TLS_REQUIRER,
             remote_app=app_name,
         )
         self.harness.add_relation_unit(


### PR DESCRIPTION
# Description

### **Note**
**Feel free to propose new names.**

### **Context**:
The `tls-constraints` charm acts as a proxy between a requirer and a provider charm, meaning it is a requirer and a provider at the same time leading to confusion in the terminology used when talking about the role of the charm compared to the requirer and provider charms and its relations to them.

When integrating the charm to a requirer and a provider it can be confusing for the user to chose which endpoint should they integrate to which charm, especially using the current names `certificates-provides` and `certificates-requires`. 
For example is the `certificates-provides` an interface to connect to the provider charm or actually as the name suggests it is the endpoint providing the certificate therefore should be used to integrate with the requirer.

The charm will not work as expected for the users if they mixup the endpoints.

It is important to keep this in mind when evaluating any names for the endpoints.


### **New Names:**
A few rules applied when thinking of a name:
- It should be clear to the user.
- Indicative of the direction of the relation
- Accurately reflect the role of the charm
- Should be consistent

Based on that I came up with the following names
<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-169a2be5-7fff-f5ab-fcf4-91de3b6be2c2"><div dir="ltr" style="margin-left:0pt;" align="left">
Relation between constraints and cert provider | Relation between constraints and cert requirer
-- | --
certificates-upstream | certificates-downstream
certificates-requires | certificates-downstream
certificates-requires-from-provider | certificates-provides-to-requirer
relation-to-provider | relation-to-requirer
requests-certificates | applies-constraints
applies-constraints | provides-certificates
constraints | certificates
certificates-filters | requests-filters
  |  
</div></b>

The issue with most of the names was that most of them can be interchangeable depending on how we read it.
So to reduce the confusion even more I think we should:
- Remove the words `requires` and `provides` from the names
- Have more emphasis on the direction of the relation in the name instead of the role of the charm

Based on this I could filter the names above and keep: `certificates-upstream` and `certificates-downstream`.
`certificates-downstream` was inspired by a relation name in the `cos-proxy-operator` [here](https://github.com/canonical/cos-proxy-operator/blob/main/metadata.yaml#L18)
# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
