### PR TITLE
feat: Add filtering skeleton

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -128,6 +128,11 @@ class TLSConstraintsCharm(CharmBase):
             self.certificates_provider.request_certificate_creation(
                 csr, event.is_ca
             )
+        else:
+            logger.warn(
+                "Certificate Request for relation ID %d was denied. Details in previous logs.",
+                event.relation_id
+            )
 
     def _on_certificate_revocation_request(self, event: CertificateRevocationRequestEvent) -> None:
         """Handle certificate revocation request events.

--- a/src/charm.py
+++ b/src/charm.py
@@ -8,7 +8,7 @@ Certificates are provided by the operator through Juju configs.
 """
 
 import logging
-from typing import Optional
+from typing import Optional, Protocol
 
 from charms.tls_certificates_interface.v3.tls_certificates import (
     AllCertificatesInvalidatedEvent,
@@ -24,10 +24,30 @@ from ops.framework import EventBase
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus
 
+from lib.charms.tls_certificates_interface.v3.tls_certificates import RequirerCSR
+
 logger = logging.getLogger(__name__)
 
 RELATION_NAME_TO_TLS_REQUIRER = "certificates-downstream"
 RELATION_NAME_TO_TLS_PROVIDER = "certificates-upstream"
+
+
+class CsrFilter(Protocol):
+    """Protocol class defining a CSR filter for applying constraints."""
+
+    def evaluate(self, csr: bytes, relation_id: int, requirer_csrs: list[RequirerCSR]) -> bool:
+        """Evaluate if the provided CSR should be allowed.
+
+        Args:
+            csr (bytes): CSR to evaluate
+            relation_id (int): ID of the relation sending the CSR
+            requirer_csrs (list): All requirer CSRs received for comparison
+
+        Returns:
+            bool: True if the CSR is allowed, False otherwise.
+
+        """
+        ...
 
 
 class TLSConstraintsCharm(CharmBase):
@@ -104,9 +124,10 @@ class TLSConstraintsCharm(CharmBase):
             event.defer()
             self.unit.status = BlockedStatus("Need a relation to a TLS certificates provider")
             return
-        self.certificates_provider.request_certificate_creation(
-            event.certificate_signing_request.encode(), event.is_ca
-        )
+        if self._is_certificate_allowed(event):
+            self.certificates_provider.request_certificate_creation(
+                event.certificate_signing_request.encode(), event.is_ca
+            )
 
     def _on_certificate_revocation_request(self, event: CertificateRevocationRequestEvent) -> None:
         """Handle certificate revocation request events.
@@ -214,6 +235,34 @@ class TLSConstraintsCharm(CharmBase):
             )
             return None
         return relation_ids.pop()
+
+    def _is_certificate_allowed(self, event: CertificateCreationRequestEvent) -> bool:
+        """Decide if the certificate should be allowed.
+
+        Args:
+            event (CertificateCreationRequestEvent): Event for a certificate creation
+
+        Returns:
+            True if the certificate should be allowed, False otherwise
+        """
+        filters = self._get_csr_filters()
+        all_requirers_csrs = self.certificates_requirers.get_requirer_csrs()
+        if not all(filter.evaluate(event.certificate_signing_request.encode(),
+                                   event.relation_id,
+                                   all_requirers_csrs)
+                   for filter in filters):
+            return False
+        return True
+
+    def _get_csr_filters(self) -> list[CsrFilter]:
+        """Get all CsrFilters to apply.
+
+        The individual filters are instantiated based on the charm configuration.
+
+        Returns:
+            list of CsrFilters to apply
+        """
+        return []
 
 
 if __name__ == "__main__":

--- a/src/charm.py
+++ b/src/charm.py
@@ -16,6 +16,7 @@ from charms.tls_certificates_interface.v3.tls_certificates import (
     CertificateCreationRequestEvent,
     CertificateInvalidatedEvent,
     CertificateRevocationRequestEvent,
+    RequirerCSR,
     TLSCertificatesProvidesV3,
     TLSCertificatesRequiresV3,
 )
@@ -23,8 +24,6 @@ from ops.charm import CharmBase
 from ops.framework import EventBase
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus
-
-from lib.charms.tls_certificates_interface.v3.tls_certificates import RequirerCSR
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
# Description

This PR adds the skeleton for filtering incoming CSR. It defines a `Protocol` that will be implemented by all future filters, and defines the charm methods that will instantiate all filters and apply all of them. The request will be ignored if any of the filters return `False`.

There are currently no filters implemented, and with that, no change of behavior.

The logic was tested locally with dummy filters to deny or allow everything.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
