### PR TITLE
feat: Limit to one request config option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,6 @@
+options:
+  limit-to-one-request:
+    default: False
+    type: boolean
+    description: |
+      Limit to one request will only allow a single CSR from any requirer

--- a/src/charm.py
+++ b/src/charm.py
@@ -56,6 +56,10 @@ class LimitToOneRequest:
         """Accept CSR if its the first CSR of a relation or the renewal of the existing CSR."""
         relevant_csrs = [csr for csr in requirer_csrs if csr.relation_id == relation_id]
         if len(relevant_csrs) > 1:
+            logger.warning(
+                "Denied CSR for relation_id: %d. Only a single CSR is allowed for application.",
+                relation_id,
+            )
             return False
         return True
 
@@ -140,7 +144,7 @@ class TLSConstraintsCharm(CharmBase):
         if self._is_certificate_allowed(csr, event.relation_id):
             self.certificates_provider.request_certificate_creation(csr, event.is_ca)
         else:
-            logger.warn(
+            logger.warning(
                 "Certificate Request for relation ID %d was denied. Details in previous logs.",
                 event.relation_id,
             )

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from juju.application import Application
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -22,8 +23,7 @@ RELATION_NAME_TO_TLS_REQUIRER = "certificates-downstream"
 RELATION_NAME_TO_TLS_PROVIDER = "certificates-upstream"
 
 
-@pytest.fixture(scope="module")
-@pytest.mark.abort_on_fail
+@pytest.fixture(scope="module", autouse=True)
 async def build_and_deploy(ops_test: OpsTest):
     """Build the charm-under-test and deploy it."""
     assert ops_test.model
@@ -54,7 +54,6 @@ async def build_and_deploy(ops_test: OpsTest):
 
 async def test_given_charm_is_not_related_to_provider_when_deploy_then_status_is_blocked(
     ops_test: OpsTest,
-    build_and_deploy,
 ):
     assert ops_test.model
     await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
@@ -62,10 +61,9 @@ async def test_given_charm_is_not_related_to_provider_when_deploy_then_status_is
 
 async def test_given_provider_is_related_then_status_is_active(
     ops_test: OpsTest,
-    build_and_deploy,
 ):
     assert ops_test.model
-    await ops_test.model.add_relation(
+    await ops_test.model.integrate(
         relation1=f"{APPLICATION_NAME}:{RELATION_NAME_TO_TLS_PROVIDER}",
         relation2=TLS_PROVIDER_CHARM_NAME,
     )
@@ -75,10 +73,9 @@ async def test_given_provider_is_related_then_status_is_active(
 
 async def test_given_tls_requirer1_is_deployed_and_related_then_certificate_is_created_and_passed_correctly(  # noqa: E501
     ops_test: OpsTest,
-    build_and_deploy,
 ):
     assert ops_test.model
-    await ops_test.model.add_relation(
+    await ops_test.model.integrate(
         relation1=f"{APPLICATION_NAME}:{RELATION_NAME_TO_TLS_REQUIRER}", relation2=TLS_REQUIRER1
     )
     await ops_test.model.wait_for_idle(
@@ -94,10 +91,9 @@ async def test_given_tls_requirer1_is_deployed_and_related_then_certificate_is_c
 
 async def test_given_tls_requirer2_is_deployed_and_related_then_certificate_is_created_passed_correctly_and_different(  # noqa: E501
     ops_test: OpsTest,
-    build_and_deploy,
 ):
     assert ops_test.model
-    await ops_test.model.add_relation(
+    await ops_test.model.integrate(
         relation1=f"{APPLICATION_NAME}:{RELATION_NAME_TO_TLS_REQUIRER}",
         relation2=TLS_REQUIRER2,
     )
@@ -116,18 +112,43 @@ async def test_given_tls_requirer2_is_deployed_and_related_then_certificate_is_c
     assert action_output1["csr"] != action_output2["csr"]
 
 
-async def run_get_certificate_action(ops_test: OpsTest, app_name: str) -> dict:
-    """Run `get-certificate` on the first unit of app_name.
+async def test_given_tls_requirer1_has_first_csr_constraint_then_second_csr_rejected(
+    ops_test: OpsTest,
+):
+    assert ops_test.model
+    constraints_app = ops_test.model.applications[APPLICATION_NAME]
+    assert isinstance(constraints_app, Application)
+    await constraints_app.set_config({"limit-to-one-request": "True"})
+
+    requirer1_app = ops_test.model.applications[TLS_REQUIRER1]
+    assert isinstance(requirer1_app, Application)
+    await requirer1_app.scale(2)
+    await ops_test.model.wait_for_idle(
+        apps=[TLS_REQUIRER1, APPLICATION_NAME], status="active", timeout=1000
+    )
+
+    action_output0 = await run_get_certificate_action(ops_test, TLS_REQUIRER1)
+    assert action_output0["certificate"] is not None
+
+    action_output1 = await run_get_certificate_action(ops_test, TLS_REQUIRER1, 1)
+    assert action_output1.get("certificate") is None
+
+
+async def run_get_certificate_action(
+    ops_test: OpsTest, app_name: str, unit_number: int = 0
+) -> dict:
+    """Run `get-certificate` on a unit of app_name.
 
     Args:
         ops_test (OpsTest): OpsTest
         app_name (str): Application Name to target
+        unit_number (int): Unit number of the application
 
     Returns:
         dict: Action output
     """
     assert ops_test.model
-    tls_requirer_unit = ops_test.model.units[f"{app_name}/0"]
+    tls_requirer_unit = ops_test.model.units[f"{app_name}/{unit_number}"]
     assert tls_requirer_unit
     action = await tls_requirer_unit.run_action(
         action_name="get-certificate",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -204,7 +204,7 @@ class TestCharm(unittest.TestCase):
                 *[
                     json.loads(
                         self.harness.get_relation_data(requirer_relation_id, f"{appname}/{i}").get(
-                            "certificate_signing_requests"
+                            "certificate_signing_requests", ""
                         )
                     )
                     for i in range(2)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,5 +1,6 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
+import itertools
 import json
 import unittest
 from unittest.mock import Mock
@@ -175,6 +176,47 @@ class TestCharm(unittest.TestCase):
         )
         self.assertEqual(requirers_certificates[0].csr, "test_csr")
         self.assertEqual(requirers_certificates[0].certificate, "test_cert")
+
+    def test_given_limit_to_one_request_set_when_second_certificate_requested_then_certificate_not_generated(  # noqa: E501
+        self,
+    ) -> None:
+        self.harness.update_config({"limit-to-one-request": True})
+
+        self._integrate_provider()
+        appname = "certificates-requirer"
+        requirer_relation_id = self._integrate_requirer(appname, 0)
+        self.harness.add_relation_unit(
+            relation_id=requirer_relation_id,
+            remote_unit_name=f"{appname}/{1}",
+        )
+        self.harness.update_relation_data(
+            requirer_relation_id,
+            "certificates-requirer/0",
+            key_values={"certificate_signing_requests": get_json_csr_list()},
+        )
+        self.harness.update_relation_data(
+            requirer_relation_id,
+            "certificates-requirer/1",
+            key_values={"certificate_signing_requests": get_json_csr_list(csr="test_csr2")},
+        )
+        databags = list(
+            itertools.chain(
+                *[
+                    json.loads(
+                        self.harness.get_relation_data(requirer_relation_id, f"{appname}/{i}").get(
+                            "certificate_signing_requests"
+                        )
+                    )
+                    for i in range(2)
+                ]
+            )
+        )
+        certificates_passed_along = (
+            self.harness.charm.certificates_provider.get_certificate_signing_requests()
+        )
+
+        assert len(databags) == 2
+        assert len(certificates_passed_along) == 1
 
     def test_given_no_requested_certificate_when_certificate_available_then_error_is_logged(
         self,


### PR DESCRIPTION
# Description

This PR builds upon @ghislainbourgeois's skeleton to provide a config option that blocks applications from requesting more than 1 CSR.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
