### PR TITLE
chore: use tls requirer from stable risk

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -30,23 +30,22 @@ async def deploy(ops_test: OpsTest, request):
     await ops_test.model.deploy(
         TLS_PROVIDER_CHARM_NAME,
         application_name=TLS_PROVIDER_CHARM_NAME,
-        channel="edge",
+        channel="stable",
     )
     await ops_test.model.deploy(
         TLS_REQUIRER_CHARM_NAME,
         application_name=TLS_REQUIRER1,
-        channel="edge",
+        channel="stable",
     )
     await ops_test.model.deploy(
         TLS_REQUIRER_CHARM_NAME,
         application_name=TLS_REQUIRER2,
-        channel="edge",
+        channel="stable",
     )
     await ops_test.model.deploy(
         charm,
         application_name=APPLICATION_NAME,
         series="jammy",
-        trust=True,
     )
 
 


### PR DESCRIPTION
# Description

Use tls requirer from stable risk, reducing the risk of tests failing because of issues in other charms used in tests.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
