### PR TITLE
feat: Add LimitToFirstRequester filter

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,9 @@
 options:
+  limit-to-first-requester:
+    default: True
+    type: boolean
+    description: |
+      Limit requested identifiers (hostnames, IPs and OIDs) to first requester
   limit-to-one-request:
     default: False
     type: boolean

--- a/src/charm.py
+++ b/src/charm.py
@@ -8,7 +8,8 @@ Certificates are provided by the operator through Juju configs.
 """
 
 import logging
-from typing import Optional, Protocol
+from itertools import chain
+from typing import Mapping, Optional, Protocol
 
 from charms.tls_certificates_interface.v3.tls_certificates import (
     AllCertificatesInvalidatedEvent,
@@ -20,6 +21,8 @@ from charms.tls_certificates_interface.v3.tls_certificates import (
     TLSCertificatesProvidesV3,
     TLSCertificatesRequiresV3,
 )
+from cryptography import x509
+from cryptography.x509.oid import NameOID
 from ops.charm import CharmBase
 from ops.framework import EventBase
 from ops.main import main
@@ -61,6 +64,52 @@ class LimitToOneRequest:
                 relation_id,
             )
             return False
+        return True
+
+
+class LimitToFirstRequester:
+    """Filter the CSR as to only allow the first requester to get a specific identifier."""
+
+    DENY_MSG = "CSR denied for relation ID %d, %s '%s' already requested."
+
+    def __init__(self, reserved_identifiers: Mapping):
+        self._reserved_identifiers = reserved_identifiers
+
+    def evaluate(self, csr: bytes, relation_id: int, requirer_csrs: list[RequirerCSR]) -> bool:
+        """Accept the CSR if no other relation previously requested any covered identifiers.
+
+        Identifiers that need to be unique are the Subject, all Subject Alternative Names,
+        all Subject Alternative IPs and all Subject Alternative OIDs.
+        """
+        csr_object = x509.load_pem_x509_csr(csr)
+        subjects = [
+            cn.value for cn in csr_object.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+        ]
+        san = csr_object.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+        for dns in chain(san.get_values_for_type(x509.DNSName), subjects):
+            if (
+                dns in self._reserved_identifiers.get("dns", {})
+                and self._reserved_identifiers["dns"][dns] != relation_id
+            ):
+                logger.warning(self.DENY_MSG, relation_id, "DNS", dns)
+                return False
+        for ip in chain(san.get_values_for_type(x509.IPAddress), subjects):
+            if (
+                str(ip) in self._reserved_identifiers.get("ip", {})
+                and self._reserved_identifiers["ip"][str(ip)] != relation_id
+            ):
+                logger.warning(self.DENY_MSG, relation_id, "IP", ip)
+                return False
+        for oid in chain(
+            (getattr(o, "dotted_string", "") for o in san.get_values_for_type(x509.RegisteredID)),
+            subjects
+        ):
+            if (
+                oid in self._reserved_identifiers.get("oid", {})
+                and self._reserved_identifiers["oid"][oid] != relation_id
+            ):
+                logger.warning(self.DENY_MSG, relation_id, "OID", oid)
+                return False
         return True
 
 
@@ -283,6 +332,8 @@ class TLSConstraintsCharm(CharmBase):
         filters = []
         if self.config.get("limit-to-one-request", None):
             filters.append(LimitToOneRequest())
+        if self.config.get("limit-to-first-requester", False):
+            filters.append(LimitToFirstRequester({}))
 
         return filters
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -89,7 +89,10 @@ class LimitToFirstRequester:
         subjects = [
             cn.value for cn in csr_object.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
         ]
-        san = csr_object.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+        try:
+            san = csr_object.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+        except x509.ExtensionNotFound:
+            san = x509.SubjectAlternativeName([])
         for dns in chain(san.get_values_for_type(x509.DNSName), subjects):
             if (dns in self._registered_dns and self._registered_dns[dns] != relation_id):
                 logger.warning(self.DENY_MSG, relation_id, "DNS", dns)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -471,6 +471,7 @@ class TestCharm:
     def test_given_limit_to_first_requirer_filter_when_config_set_then_filter_available(  # noqa: E501
         self,
     ) -> None:
+        self._integrate_provider()
         self.harness.update_config({"limit-to-first-requester": True})
         assert len(self.harness.charm._get_csr_filters()) > 0
         assert isinstance(self.harness.charm._get_csr_filters()[0], LimitToFirstRequester)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,7 +5,7 @@ import json
 from unittest.mock import Mock
 
 import pytest
-from charm import LimitToOneRequest, TLSConstraintsCharm
+from charm import LimitToFirstRequester, LimitToOneRequest, TLSConstraintsCharm
 from charms.tls_certificates_interface.v3.tls_certificates import (
     CertificateAvailableEvent,
     CertificateCreationRequestEvent,
@@ -36,6 +36,7 @@ class TestCharm:
     def setUp(self):
         self.harness = testing.Harness(TLSConstraintsCharm)
         self.harness.set_leader(True)
+        self.harness.update_config({"limit-to-first-requester": False})
         self.harness.begin()
         yield
         self.harness.cleanup
@@ -466,3 +467,10 @@ class TestCharm:
         ]
         filter = LimitToOneRequest()
         assert filter.evaluate(b"", 1, requirer_csrs) is False
+
+    def test_given_limit_to_first_requirer_filter_when_config_set_then_filter_available(  # noqa: E501
+        self,
+    ) -> None:
+        self.harness.update_config({"limit-to-first-requester": True})
+        assert len(self.harness.charm._get_csr_filters()) > 0
+        assert isinstance(self.harness.charm._get_csr_filters()[0], LimitToFirstRequester)

--- a/tests/unit/test_limit_to_first_requester.py
+++ b/tests/unit/test_limit_to_first_requester.py
@@ -160,3 +160,14 @@ class TestLimitToFirstRequester:
         filter.evaluate(CSR, MY_RELATION_ID, [])
         logs = [(record.levelname, record.module, record.message) for record in caplog.records]
         assert len(logs) == 0
+
+    def test_given_csr_without_sans_extension_when_evaluate_then_does_not_crash(self):
+        csr = generate_csr(
+            private_key=PRIVATE_KEY,
+            subject=REQUESTED_SUBJECT,
+            organization="Example inc.",
+            email_address="admin@example.com",
+            country_name="CA",
+        )
+        filter = LimitToFirstRequester(registered_dns={}, registered_ips={}, registered_oids={})
+        assert filter.evaluate(csr, MY_RELATION_ID, []) is True

--- a/tests/unit/test_limit_to_first_requester.py
+++ b/tests/unit/test_limit_to_first_requester.py
@@ -5,12 +5,14 @@ from random import choice
 import pytest
 from charm import LimitToFirstRequester
 from charms.tls_certificates_interface.v3.tls_certificates import (
+    RequirerCSR,
     generate_csr,
     generate_private_key,
 )
 
 MY_RELATION_ID = 1
 OTHER_RELATION_ID = 2
+PROVIDER_RELATION_ID = 999
 
 REQUESTED_SUBJECT = "Test Subject"
 REQUESTED_DNS = ["test-0.example.com", "test-internal.example.com"]
@@ -18,6 +20,16 @@ REQUESTED_IPS = ["2.2.2.2", "10.142.42.2"]
 REQUESTED_OIDS = ["1.2.3.4.42.120", "1.2.3.3.42.121"]
 
 PRIVATE_KEY = generate_private_key()
+OLD_CSR = generate_csr(
+    private_key=PRIVATE_KEY,
+    subject=REQUESTED_SUBJECT,
+    sans_dns=REQUESTED_DNS,
+    sans_ip=REQUESTED_IPS,
+    sans_oid=REQUESTED_OIDS,
+    organization="Example inc.",
+    email_address="admin@example.com",
+    country_name="CA",
+)
 CSR = generate_csr(
     private_key=PRIVATE_KEY,
     subject=REQUESTED_SUBJECT,
@@ -28,135 +40,225 @@ CSR = generate_csr(
     email_address="admin@example.com",
     country_name="CA",
 )
+RESERVED_SUBJECTS = [f"Reserved{i}" for i in range(4)]
+RESERVED_DNS = [f"reserved{i}.example.com" for i in range(4)]
+RESERVED_IPS = [f"10.0.0.{i}" for i in range(4)]
+RESERVED_OIDS = [f"1.2.3.4.42.20{i}" for i in range(4)]
+RESERVED_CSRS = [
+    generate_csr(
+        private_key=PRIVATE_KEY,
+        subject=RESERVED_SUBJECTS[0],
+        organization="Example inc.",
+        email_address="admin@example.com",
+        country_name="CA",
+    ),
+    generate_csr(
+        private_key=PRIVATE_KEY,
+        subject=RESERVED_SUBJECTS[1],
+        sans_dns=RESERVED_DNS,
+        organization="Example inc.",
+        email_address="admin@example.com",
+        country_name="CA",
+    ),
+    generate_csr(
+        private_key=PRIVATE_KEY,
+        subject=RESERVED_SUBJECTS[2],
+        sans_ip=RESERVED_IPS,
+        organization="Example inc.",
+        email_address="admin@example.com",
+        country_name="CA",
+    ),
+    generate_csr(
+        private_key=PRIVATE_KEY,
+        subject=RESERVED_SUBJECTS[3],
+        sans_oid=RESERVED_OIDS,
+        organization="Example inc.",
+        email_address="admin@example.com",
+        country_name="CA",
+    ),
+]
+
+
+ALLOWED_CSRS = [
+    RequirerCSR(
+        relation_id=PROVIDER_RELATION_ID,
+        application_name="other_app",
+        unit_name="other_app/0",
+        csr=csr.decode("utf-8"),
+        is_ca=False
+    ) for csr in RESERVED_CSRS
+]
+
+REQUIRER_CSRS = [
+    RequirerCSR(
+        relation_id=OTHER_RELATION_ID,
+        application_name="other_app",
+        unit_name="other_app/0",
+        csr=csr.decode("utf-8"),
+        is_ca=False
+    ) for csr in RESERVED_CSRS
+]
+
+OLD_REQUIRER_CSR = RequirerCSR(
+    relation_id=MY_RELATION_ID,
+    application_name="my_app",
+    unit_name="my_app/0",
+    csr=OLD_CSR.decode("utf-8"),
+    is_ca=False
+)
 
 
 class TestLimitToFirstRequester:
 
     @pytest.mark.parametrize(
-        "dns,ip,oid,expected",
+        "csr,relation_id,expected",
         [
-            pytest.param({}, {}, {}, True, id="no_previous_requesters"),
+            pytest.param(CSR, MY_RELATION_ID, True, id="previous_requesters_do_not_match"),
             pytest.param(
-                {
-                    "pizza.example.com": OTHER_RELATION_ID,
-                    "poulah.example.com": OTHER_RELATION_ID,
-                },
-                {
-                    "1.1.1.1": OTHER_RELATION_ID,
-                    "192.168.0.1": OTHER_RELATION_ID,
-                },
-                {
-                    "1.2.3.4.42.500": OTHER_RELATION_ID,
-                    "1.2.3.4.42.120.55": OTHER_RELATION_ID,
-                },
-                True,
-                id="previous_requesters_do_not_match"
-            ),
-            pytest.param(
-                {REQUESTED_SUBJECT: OTHER_RELATION_ID},
-                {},
-                {},
+                generate_csr(private_key=PRIVATE_KEY, subject=choice(RESERVED_DNS)),
+                MY_RELATION_ID,
                 False,
                 id="dns_subject_previously_requested",
             ),
             pytest.param(
-                {REQUESTED_SUBJECT: MY_RELATION_ID}, {}, {},
-                True,
-                id="dns_subject_previously_requested_by_us",
-            ),
-            pytest.param(
-                {choice(REQUESTED_DNS): OTHER_RELATION_ID}, {}, {},
-                False,
-                id="dns_san_previously_requested",
-            ),
-            pytest.param(
-                {choice(REQUESTED_DNS): MY_RELATION_ID}, {}, {},
-                True,
-                id="ip_san_previously_requested_by_us",
-            ),
-            pytest.param(
-                {}, {REQUESTED_SUBJECT: OTHER_RELATION_ID}, {},
+                generate_csr(private_key=PRIVATE_KEY, subject=choice(RESERVED_IPS)),
+                MY_RELATION_ID,
                 False,
                 id="ip_subject_previously_requested",
             ),
             pytest.param(
-                {}, {REQUESTED_SUBJECT: MY_RELATION_ID}, {},
-                True,
-                id="ip_subject_previously_requested_by_us",
-            ),
-            pytest.param(
-                {}, {choice(REQUESTED_IPS): OTHER_RELATION_ID}, {},
-                False,
-                id="ip_san_previously_requested",
-            ),
-            pytest.param(
-                {}, {choice(REQUESTED_IPS): MY_RELATION_ID}, {},
-                True,
-                id="ip_san_previously_requested_by_us",
-            ),
-            pytest.param(
-                {}, {}, {REQUESTED_SUBJECT: OTHER_RELATION_ID},
+                generate_csr(private_key=PRIVATE_KEY, subject=choice(RESERVED_OIDS)),
+                MY_RELATION_ID,
                 False,
                 id="oid_subject_previously_requested",
             ),
             pytest.param(
-                {}, {}, {REQUESTED_SUBJECT: MY_RELATION_ID},
-                True,
-                id="oid_subject_previously_requested_by_us",
+                generate_csr(
+                    private_key=PRIVATE_KEY,
+                    subject=REQUESTED_SUBJECT,
+                    sans_dns=[choice(RESERVED_DNS)]
+                ),
+                MY_RELATION_ID,
+                False,
+                id="dns_san_previously_requested",
             ),
             pytest.param(
-                {}, {}, {choice(REQUESTED_OIDS): OTHER_RELATION_ID},
+                generate_csr(
+                    private_key=PRIVATE_KEY,
+                    subject=REQUESTED_SUBJECT,
+                    sans_ip=[choice(RESERVED_IPS)]
+                ),
+                MY_RELATION_ID,
+                False,
+                id="ip_san_previously_requested",
+            ),
+            pytest.param(
+                generate_csr(
+                    private_key=PRIVATE_KEY,
+                    subject=REQUESTED_SUBJECT,
+                    sans_oid=[choice(RESERVED_OIDS)]
+                ),
+                MY_RELATION_ID,
                 False,
                 id="oid_san_previously_requested",
             ),
             pytest.param(
-                {}, {}, {choice(REQUESTED_OIDS): MY_RELATION_ID},
+                generate_csr(private_key=PRIVATE_KEY, subject=choice(RESERVED_DNS)),
+                OTHER_RELATION_ID,
+                True,
+                id="dns_subject_previously_requested_by_us",
+            ),
+            pytest.param(
+                generate_csr(private_key=PRIVATE_KEY, subject=choice(RESERVED_IPS)),
+                OTHER_RELATION_ID,
+                True,
+                id="ip_subject_previously_requested_by_us",
+            ),
+            pytest.param(
+                generate_csr(private_key=PRIVATE_KEY, subject=choice(RESERVED_OIDS)),
+                OTHER_RELATION_ID,
+                True,
+                id="oid_subject_previously_requested_by_us",
+            ),
+            pytest.param(
+                generate_csr(
+                    private_key=PRIVATE_KEY,
+                    subject=REQUESTED_SUBJECT,
+                    sans_dns=[choice(RESERVED_DNS)]
+                ),
+                OTHER_RELATION_ID,
+                True,
+                id="dns_san_previously_requested_by_us",
+            ),
+            pytest.param(
+                generate_csr(
+                    private_key=PRIVATE_KEY,
+                    subject=REQUESTED_SUBJECT,
+                    sans_ip=[choice(RESERVED_IPS)]
+                ),
+                OTHER_RELATION_ID,
+                True,
+                id="ip_san_previously_requested_by_us",
+            ),
+            pytest.param(
+                generate_csr(
+                    private_key=PRIVATE_KEY,
+                    subject=REQUESTED_SUBJECT,
+                    sans_oid=[choice(RESERVED_OIDS)]
+                ),
+                OTHER_RELATION_ID,
                 True,
                 id="oid_san_previously_requested_by_us",
             ),
         ],
     )
     def test_given_previous_requesters_when_evaluate_csr_then_csr_is_allowed_or_denied(
-        self, dns, ip, oid, expected
+        self, csr, relation_id, expected
     ):
-        filter = LimitToFirstRequester(registered_dns=dns, registered_ips=ip, registered_oids=oid)
-        assert filter.evaluate(CSR, MY_RELATION_ID, []) is expected
+        filter = LimitToFirstRequester(allowed_csrs=ALLOWED_CSRS)
+        assert filter.evaluate(csr, relation_id, REQUIRER_CSRS) is expected
 
     @pytest.mark.parametrize(
-        "dns,ip,oid,expected",
+        "csr,expected",
         [
             pytest.param(
-                {REQUESTED_SUBJECT: OTHER_RELATION_ID}, {}, {},
+                generate_csr(private_key=PRIVATE_KEY, subject=RESERVED_SUBJECTS[0]),
                 f"CSR denied for relation ID {MY_RELATION_ID}, "
-                + f"DNS '{REQUESTED_SUBJECT}' already requested.",
+                + f"DNS '{RESERVED_SUBJECTS[0]}' already requested.",
                 id="dns_san_previously_requested",
             ),
             pytest.param(
-                {}, {REQUESTED_SUBJECT: OTHER_RELATION_ID}, {},
+                generate_csr(private_key=PRIVATE_KEY, subject=RESERVED_DNS[0]),
                 f"CSR denied for relation ID {MY_RELATION_ID}, "
-                + f"IP '{REQUESTED_SUBJECT}' already requested.",
+                + f"DNS '{RESERVED_DNS[0]}' already requested.",
+                id="dns_san_previously_requested",
+            ),
+            pytest.param(
+                generate_csr(private_key=PRIVATE_KEY, subject=RESERVED_IPS[0]),
+                f"CSR denied for relation ID {MY_RELATION_ID}, "
+                + f"IP '{RESERVED_IPS[0]}' already requested.",
                 id="ip_subject_previously_requested",
             ),
             pytest.param(
-                {}, {}, {REQUESTED_SUBJECT: OTHER_RELATION_ID},
+                generate_csr(private_key=PRIVATE_KEY, subject=RESERVED_OIDS[0]),
                 f"CSR denied for relation ID {MY_RELATION_ID}, "
-                + f"OID '{REQUESTED_SUBJECT}' already requested.",
+                + f"OID '{RESERVED_OIDS[0]}' already requested.",
                 id="oid_san_previously_requested",
             ),
         ],
     )
     def test_given_previous_requesters_when_evaluate_csr_then_denials_are_logged(
-        self, dns, ip, oid, expected, caplog
+        self, csr, expected, caplog
     ):
-        filter = LimitToFirstRequester(registered_dns=dns, registered_ips=ip, registered_oids=oid)
-        filter.evaluate(CSR, MY_RELATION_ID, [])
+        filter = LimitToFirstRequester(allowed_csrs=ALLOWED_CSRS)
+        filter.evaluate(csr, MY_RELATION_ID, REQUIRER_CSRS)
         logs = [(record.levelname, record.module, record.message) for record in caplog.records]
         assert ("WARNING", "charm", expected) in logs
 
     def test_given_previous_requesters_when_evaluate_csr_then_approvals_are_not_logged(
         self, caplog
     ):
-        filter = LimitToFirstRequester(registered_dns={}, registered_ips={}, registered_oids={})
+        filter = LimitToFirstRequester(allowed_csrs=[])
         filter.evaluate(CSR, MY_RELATION_ID, [])
         logs = [(record.levelname, record.module, record.message) for record in caplog.records]
         assert len(logs) == 0
@@ -169,5 +271,5 @@ class TestLimitToFirstRequester:
             email_address="admin@example.com",
             country_name="CA",
         )
-        filter = LimitToFirstRequester(registered_dns={}, registered_ips={}, registered_oids={})
+        filter = LimitToFirstRequester(allowed_csrs=[])
         assert filter.evaluate(csr, MY_RELATION_ID, []) is True

--- a/tests/unit/test_limit_to_first_requester.py
+++ b/tests/unit/test_limit_to_first_requester.py
@@ -1,0 +1,173 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+from random import choice
+
+import pytest
+from charm import LimitToFirstRequester
+from charms.tls_certificates_interface.v3.tls_certificates import (
+    generate_csr,
+    generate_private_key,
+)
+
+MY_RELATION_ID = 1
+OTHER_RELATION_ID = 2
+
+REQUESTED_SUBJECT = "Test Subject"
+REQUESTED_DNS = ["test-0.example.com", "test-internal.example.com"]
+REQUESTED_IPS = ["2.2.2.2", "10.142.42.2"]
+REQUESTED_OIDS = ["1.2.3.4.42.120", "1.2.3.3.42.121"]
+
+PRIVATE_KEY = generate_private_key()
+CSR = generate_csr(
+    private_key=PRIVATE_KEY,
+    subject=REQUESTED_SUBJECT,
+    sans_dns=REQUESTED_DNS,
+    sans_ip=REQUESTED_IPS,
+    sans_oid=REQUESTED_OIDS,
+    organization="Example inc.",
+    email_address="admin@example.com",
+    country_name="CA",
+)
+
+
+class TestLimitToFirstRequester:
+
+    @pytest.mark.parametrize(
+        "requested_identifiers,expected",
+        [
+            pytest.param({}, True, id="no_previous_requesters"),
+            pytest.param({"dns": {}, "ip": {}, "oid": {}}, True, id="empty_previous_requesters"),
+            pytest.param(
+                {
+                    "dns": {
+                        "pizza.example.com": OTHER_RELATION_ID,
+                        "poulah.example.com": OTHER_RELATION_ID,
+                    },
+                    "ip": {
+                        "1.1.1.1": OTHER_RELATION_ID,
+                        "192.168.0.1": OTHER_RELATION_ID,
+                    },
+                    "oid": {
+                        "1.2.3.4.42.500": OTHER_RELATION_ID,
+                        "1.2.3.4.42.120.55": OTHER_RELATION_ID,
+                    }
+                },
+                True,
+                id="previous_requesters_do_not_match"
+            ),
+            pytest.param(
+                {
+                    "dns": {REQUESTED_SUBJECT: OTHER_RELATION_ID},
+                    "ip": {},
+                    "oid": {}
+                },
+                False,
+                id="dns_subject_previously_requested",
+            ),
+            pytest.param(
+                {"dns": {REQUESTED_SUBJECT: MY_RELATION_ID}, "ip": {}, "oid": {}},
+                True,
+                id="dns_subject_previously_requested_by_us",
+            ),
+            pytest.param(
+                {"dns": {choice(REQUESTED_DNS): OTHER_RELATION_ID}, "ip": {}, "oid": {}},
+                False,
+                id="dns_san_previously_requested",
+            ),
+            pytest.param(
+                {"dns": {choice(REQUESTED_DNS): MY_RELATION_ID}, "ip": {}, "oid": {}},
+                True,
+                id="ip_san_previously_requested_by_us",
+            ),
+            pytest.param(
+                {"dns": {}, "ip": {REQUESTED_SUBJECT: OTHER_RELATION_ID}, "oid": {}},
+                False,
+                id="ip_subject_previously_requested",
+            ),
+            pytest.param(
+                {"dns": {}, "ip": {REQUESTED_SUBJECT: MY_RELATION_ID}, "oid": {}},
+                True,
+                id="ip_subject_previously_requested_by_us",
+            ),
+            pytest.param(
+                {"dns": {}, "ip": {choice(REQUESTED_IPS): OTHER_RELATION_ID}, "oid": {}},
+                False,
+                id="ip_san_previously_requested",
+            ),
+            pytest.param(
+                {"dns": {}, "ip": {choice(REQUESTED_IPS): MY_RELATION_ID}, "oid": {}},
+                True,
+                id="ip_san_previously_requested_by_us",
+            ),
+            pytest.param(
+                {"dns": {}, "ip": {}, "oid": {REQUESTED_SUBJECT: OTHER_RELATION_ID}},
+                False,
+                id="oid_subject_previously_requested",
+            ),
+            pytest.param(
+                {"dns": {}, "ip": {}, "oid": {REQUESTED_SUBJECT: MY_RELATION_ID}},
+                True,
+                id="oid_subject_previously_requested_by_us",
+            ),
+            pytest.param(
+                {"dns": {}, "ip": {}, "oid": {choice(REQUESTED_OIDS): OTHER_RELATION_ID}},
+                False,
+                id="oid_san_previously_requested",
+            ),
+            pytest.param(
+                {"dns": {}, "ip": {}, "oid": {choice(REQUESTED_OIDS): MY_RELATION_ID}},
+                True,
+                id="oid_san_previously_requested_by_us",
+            ),
+        ],
+    )
+    def test_given_previous_requesters_when_evaluate_csr_then_csr_is_allowed_or_denied(
+        self,
+        requested_identifiers,
+        expected
+    ):
+        filter = LimitToFirstRequester(requested_identifiers)
+        assert filter.evaluate(CSR, MY_RELATION_ID, []) is expected
+
+    @pytest.mark.parametrize(
+        "requested_identifiers,expected",
+        [
+            pytest.param(
+                {"dns": {REQUESTED_SUBJECT: OTHER_RELATION_ID}, "ip": {}, "oid": {}},
+                f"CSR denied for relation ID {MY_RELATION_ID}, "
+                + f"DNS '{REQUESTED_SUBJECT}' already requested.",
+                id="dns_san_previously_requested",
+            ),
+            pytest.param(
+                {"dns": {}, "ip": {REQUESTED_SUBJECT: OTHER_RELATION_ID}, "oid": {}},
+                f"CSR denied for relation ID {MY_RELATION_ID}, "
+                + f"IP '{REQUESTED_SUBJECT}' already requested.",
+                id="ip_subject_previously_requested",
+            ),
+            pytest.param(
+                {"dns": {}, "ip": {}, "oid": {REQUESTED_SUBJECT: OTHER_RELATION_ID}},
+                f"CSR denied for relation ID {MY_RELATION_ID}, "
+                + f"OID '{REQUESTED_SUBJECT}' already requested.",
+                id="oid_san_previously_requested",
+            ),
+        ],
+    )
+    def test_given_previous_requesters_when_evaluate_csr_then_denials_are_logged(
+        self,
+        requested_identifiers,
+        expected,
+        caplog
+    ):
+        filter = LimitToFirstRequester(requested_identifiers)
+        filter.evaluate(CSR, MY_RELATION_ID, [])
+        logs = [(record.levelname, record.module, record.message) for record in caplog.records]
+        assert ("WARNING", "charm", expected) in logs
+
+    def test_given_previous_requesters_when_evaluate_csr_then_approvals_are_not_logged(
+        self,
+        caplog
+    ):
+        filter = LimitToFirstRequester({})
+        filter.evaluate(CSR, MY_RELATION_ID, [])
+        logs = [(record.levelname, record.module, record.message) for record in caplog.records]
+        assert len(logs) == 0

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 [tox]
 no_package = True
 skip_missing_interpreters = True
-env_list = format, lint, static, unit
+env_list = lint, static, unit
 min_version = 4.0.0
 
 [vars]


### PR DESCRIPTION
# Description

Adds the `LimitToFirstRequester` filter that checks an incoming CSR for any unique identifiers (DNS, IP or OID) that were previously requested by another application. Because the subject in the CSR is a x.500 Distinguished Name and the Common Name (CN) can be an arbitrary string, that CN is checked against all the types of identifiers.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
