### PR TITLE
chore: Move config docs into the config file

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,19 +3,8 @@ options:
     default: True
     type: boolean
     description: |
-      This filter is disabled by default, and can be enabled by setting the following config:
+      This filter is enabled by default
 
-      `juju config tls-constraints limit-to-one-request=True`
-      This filter only allows a single CSR to be forwarded to a provider for each application. This CSR can be switched out at any point and replaced with another, but only a single CSR from an application will ever be forwarded.
-
-      If this filter is enabled after multiple CSR’s have already been requested, the filter will deny any CSR until the number of CSR’s the requiring charm has requested is under 1.
-  limit-to-one-request:
-    default: False
-    type: boolean
-    description: |
-      This filter is enabled by default, and can be disabled by setting the following config:
-
-      `juju config tls-constraints limit-to-one-request=True`
       This filter looks at the DNS, IP and OID of the requested CSR, and reserves the field to the first application that requests it. This includes the value provided in the Common Name as well as in the Subject Alternative Name (SAN) field.
       
       Multiple units of the same application can request the same or different fields from each other, which will all be reserved to the application.
@@ -23,6 +12,15 @@ options:
       An application can release the reservation on their fields by withdrawing their CSR, in which case any other application can reserve the previously taken fields.
       
       If this option is enabled after multiple applications have requested the same SAN fields, the filter will block any new CSR from taking these fields, and will continue to block these fields until the number of requirers that share that fields falls below 1.
+  limit-to-one-request:
+    default: False
+    type: boolean
+    description: |
+      This filter is disabled by default.
+
+      This filter only allows a single CSR to be forwarded to a provider for each application. This CSR can be switched out at any point and replaced with another, but only a single CSR from an application will ever be forwarded.
+
+      If this filter is enabled after multiple CSR’s have already been requested, the filter will deny any CSR until the number of CSR’s the requiring charm has requested is under 1.
   allowed-dns:
     default: ""
     type: string

--- a/config.yaml
+++ b/config.yaml
@@ -3,9 +3,9 @@ options:
     default: True
     type: boolean
     description: |
-      This filter is enabled by default
+      Limit requested identifiers (hostnames, IPs and OIDs) to first requester.
 
-      This filter looks at the DNS, IP and OID of the requested CSR, and reserves the field to the first application that requests it. This includes the value provided in the Common Name as well as in the Subject Alternative Name (SAN) field.
+      This includes the value provided in the Common Name as well as in the Subject Alternative Name (SAN) field.
       
       Multiple units of the same application can request the same or different fields from each other, which will all be reserved to the application.
       
@@ -16,71 +16,70 @@ options:
     default: False
     type: boolean
     description: |
-      This filter is disabled by default.
+      Limit to one request will only allow a single CSR from any requirer.
 
-      This filter only allows a single CSR to be forwarded to a provider for each application. This CSR can be switched out at any point and replaced with another, but only a single CSR from an application will ever be forwarded.
+      This CSR can be switched out at any point and replaced with another, but only a single CSR from an application will ever be forwarded.
 
       If this filter is enabled after multiple CSR’s have already been requested, the filter will deny any CSR until the number of CSR’s the requiring charm has requested is under 1.
   allowed-dns:
     default: ""
     type: string
     description: |
-      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for DNS's. Ex: "myapp-([0-9]+)?\.mycompany\.com"`
+      Regex for describing custom filtering options for DNS's.
 
-      The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex.
+      The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex. Ex: "myapp-([0-9]+)?\.mycompany\.com"`
 
       If the filter is enabled after CSR’s that don’t match the regex are approved, they will not be reversed but any future CSR’s will be filtered including the ones that are coming from the same application. This may break automatic renewal requests.
   allowed-ips:
     default: ""
     type: string
     description: |
-      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for IP's. Ex: "172\.25\.0\.[0-9]*"`
-
-      The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex.
+      Regex for describing custom filtering options for IP's.
+      
+      The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex. Ex: "172\.25\.0\.[0-9]*"
 
       If the filter is enabled after CSR’s that don’t match the regex are approved, they will not be reversed but any future CSR’s will be filtered including the ones that are coming from the same application. This may break automatic renewal requests.
   allowed-oids:
     default: ""
     type: string
     description: |
-      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for OID's. Ex: "1\.3\.6\.1\.4\.1\.28978\.[0-9.]*"`
-
-      The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex.
+      Regex for describing custom filtering options for OID's.
+      
+      The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex. Ex: "1\.3\.6\.1\.4\.1\.28978\.[0-9.]*"
 
       If the filter is enabled after CSR’s that don’t match the regex are approved, they will not be reversed but any future CSR’s will be filtered including the ones that are coming from the same application. This may break automatic renewal requests.
   allowed-common-name:
     default: ""
     type: string
     description: |
-      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for the common name. Ex: "myapp-([0-9]+)?\.mycompany\.com"`
+      Regex for describing custom filtering options for common names.
 
-      The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex.
+      The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex. Ex: "myapp-([0-9]+)?\.mycompany\.com"
 
       If the filter is enabled after CSR’s that don’t match the regex are approved, they will not be reversed but any future CSR’s will be filtered including the ones that are coming from the same application. This may break automatic renewal requests.
   allowed-organization:
     default: ""
     type: string
     description: |
-      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for the organization. Ex: "Canonical Ltd\."`
-
-      The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex.
+      Regex for describing custom filtering options for organizations. 
+      The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex. Ex: "Canonical Ltd\."
 
       If the filter is enabled after CSR’s that don’t match the regex are approved, they will not be reversed but any future CSR’s will be filtered including the ones that are coming from the same application. This may break automatic renewal requests.
   allowed-email:
     default: ""
     type: string
     description: |
-      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for the email address. Ex: ".*@canonical\.com"`
+      Regex for describing custom filtering options for emails.
 
-      The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex.
+      The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex. Ex: ".*@canonical\.com"
 
       If the filter is enabled after CSR’s that don’t match the regex are approved, they will not be reversed but any future CSR’s will be filtered including the ones that are coming from the same application. This may break automatic renewal requests.
   allowed-country-code:
     default: ""
     type: string
     description: |
-      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for the country code. Ex: "(UK|US|CA|PL|AE|HU|FR|TR|IT)$"`
-
-      The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex.
+      Regex for describing custom filtering options for country codes.
+      
+      The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex. Ex: "(UK|US|CA|PL|AE|HU|FR|TR|IT)$"
 
       If the filter is enabled after CSR’s that don’t match the regex are approved, they will not be reversed but any future CSR’s will be filtered including the ones that are coming from the same application. This may break automatic renewal requests.

--- a/config.yaml
+++ b/config.yaml
@@ -25,8 +25,7 @@ options:
     default: ""
     type: string
     description: |
-      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for DNS's.
-      `juju config tls-constraints allowed-dns="myapp-([0-9]+)?\.mycompany\.com"`
+      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for DNS's. Ex: "myapp-([0-9]+)?\.mycompany\.com"`
 
       The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex.
 
@@ -35,8 +34,7 @@ options:
     default: ""
     type: string
     description: |
-      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for IP's.
-      `juju config tls-constraints allowed-ips="172\.25\.0\.[0-9]*"`
+      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for IP's. Ex: "172\.25\.0\.[0-9]*"`
 
       The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex.
 
@@ -45,8 +43,7 @@ options:
     default: ""
     type: string
     description: |
-      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for OID's.
-      `juju config tls-constraints allowed-oids="1\.3\.6\.1\.4\.1\.28978\.[0-9.]*"`
+      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for OID's. Ex: "1\.3\.6\.1\.4\.1\.28978\.[0-9.]*"`
 
       The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex.
 
@@ -55,8 +52,7 @@ options:
     default: ""
     type: string
     description: |
-      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for the common name.
-      `juju config tls-constraints allowed-common-name="myapp-([0-9]+)?\.mycompany\.com"`
+      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for the common name. Ex: "myapp-([0-9]+)?\.mycompany\.com"`
 
       The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex.
 
@@ -65,8 +61,7 @@ options:
     default: ""
     type: string
     description: |
-      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for the organization.
-      `juju config tls-constraints allowed-organization="Canonical Ltd\."`
+      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for the organization. Ex: "Canonical Ltd\."`
 
       The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex.
 
@@ -75,8 +70,7 @@ options:
     default: ""
     type: string
     description: |
-      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for the email address.
-      `juju config tls-constraints allowed-email=".*@canonical\.com"`
+      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for the email address. Ex: ".*@canonical\.com"`
 
       The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex.
 
@@ -85,8 +79,7 @@ options:
     default: ""
     type: string
     description: |
-      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for the country code.
-      `juju config tls-constraints allowed-country-code="(UK|US|CA|PL|AE|HU|FR|TR|IT)$"`
+      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for the country code. Ex: "(UK|US|CA|PL|AE|HU|FR|TR|IT)$"`
 
       The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex.
 

--- a/config.yaml
+++ b/config.yaml
@@ -3,45 +3,93 @@ options:
     default: True
     type: boolean
     description: |
-      Limit requested identifiers (hostnames, IPs and OIDs) to first requester
+      This filter is disabled by default, and can be enabled by setting the following config:
+
+      `juju config tls-constraints limit-to-one-request=True`
+      This filter only allows a single CSR to be forwarded to a provider for each application. This CSR can be switched out at any point and replaced with another, but only a single CSR from an application will ever be forwarded.
+
+      If this filter is enabled after multiple CSR’s have already been requested, the filter will deny any CSR until the number of CSR’s the requiring charm has requested is under 1.
   limit-to-one-request:
     default: False
     type: boolean
     description: |
-      Limit to one request will only allow a single CSR from any requirer
-  
+      This filter is enabled by default, and can be disabled by setting the following config:
+
+      `juju config tls-constraints limit-to-one-request=True`
+      This filter looks at the DNS, IP and OID of the requested CSR, and reserves the field to the first application that requests it. This includes the value provided in the Common Name as well as in the Subject Alternative Name (SAN) field.
+      
+      Multiple units of the same application can request the same or different fields from each other, which will all be reserved to the application.
+      
+      An application can release the reservation on their fields by withdrawing their CSR, in which case any other application can reserve the previously taken fields.
+      
+      If this option is enabled after multiple applications have requested the same SAN fields, the filter will block any new CSR from taking these fields, and will continue to block these fields until the number of requirers that share that fields falls below 1.
   allowed-dns:
     default: ""
     type: string
     description: |
-      Regex for describing custom filtering options for DNS's. Ex: "myapp-([0-9]+)?\.mycompany\.com"
+      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for DNS's.
+      `juju config tls-constraints allowed-dns="myapp-([0-9]+)?\.mycompany\.com"`
+
+      The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex.
+
+      If the filter is enabled after CSR’s that don’t match the regex are approved, they will not be reversed but any future CSR’s will be filtered including the ones that are coming from the same application. This may break automatic renewal requests.
   allowed-ips:
     default: ""
     type: string
     description: |
-      Regex for describing custom filtering options for IP's. Ex: "172\.25\.0\.[0-9]*"
+      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for IP's.
+      `juju config tls-constraints allowed-ips="172\.25\.0\.[0-9]*"`
+
+      The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex.
+
+      If the filter is enabled after CSR’s that don’t match the regex are approved, they will not be reversed but any future CSR’s will be filtered including the ones that are coming from the same application. This may break automatic renewal requests.
   allowed-oids:
     default: ""
     type: string
     description: |
-      Regex for describing custom filtering options for OID's. Ex: "1\.3\.6\.1\.4\.1\.28978\.[0-9.]*"
+      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for OID's.
+      `juju config tls-constraints allowed-oids="1\.3\.6\.1\.4\.1\.28978\.[0-9.]*"`
+
+      The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex.
+
+      If the filter is enabled after CSR’s that don’t match the regex are approved, they will not be reversed but any future CSR’s will be filtered including the ones that are coming from the same application. This may break automatic renewal requests.
   allowed-common-name:
     default: ""
     type: string
     description: |
-      Regex for describing custom filtering options for common names. Ex: "myapp-([0-9]+)?\.mycompany\.com"
+      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for the common name.
+      `juju config tls-constraints allowed-common-name="myapp-([0-9]+)?\.mycompany\.com"`
+
+      The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex.
+
+      If the filter is enabled after CSR’s that don’t match the regex are approved, they will not be reversed but any future CSR’s will be filtered including the ones that are coming from the same application. This may break automatic renewal requests.
   allowed-organization:
     default: ""
     type: string
     description: |
-      Regex for describing custom filtering options for organizations. Ex: "Canonical Ltd\."
+      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for the organization.
+      `juju config tls-constraints allowed-organization="Canonical Ltd\."`
+
+      The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex.
+
+      If the filter is enabled after CSR’s that don’t match the regex are approved, they will not be reversed but any future CSR’s will be filtered including the ones that are coming from the same application. This may break automatic renewal requests.
   allowed-email:
     default: ""
     type: string
     description: |
-      Regex for describing custom filtering options for emails. Ex: ".*@canonical\.com"
+      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for the email address.
+      `juju config tls-constraints allowed-email=".*@canonical\.com"`
+
+      The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex.
+
+      If the filter is enabled after CSR’s that don’t match the regex are approved, they will not be reversed but any future CSR’s will be filtered including the ones that are coming from the same application. This may break automatic renewal requests.
   allowed-country-code:
     default: ""
     type: string
     description: |
-      Regex for describing custom filtering options for country codes. Ex: "(UK|US|CA|PL|AE|HU|FR|TR|IT)$"
+      This filter is disabled by default, and can be enabled by setting a Regex for describing custom filtering options for the country code.
+      `juju config tls-constraints allowed-country-code="(UK|US|CA|PL|AE|HU|FR|TR|IT)$"`
+
+      The filter needs to be provided a python style regex string that will be used to filter out CSR’s with fields that don’t match with the provided regex.
+
+      If the filter is enabled after CSR’s that don’t match the regex are approved, they will not be reversed but any future CSR’s will be filtered including the ones that are coming from the same application. This may break automatic renewal requests.


### PR DESCRIPTION
# Description

Moves the explanations for the config options into the yaml file itself from https://discourse.charmhub.io/t/reference-filter-configuration/14027

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
