### PR TITLE
style: Format using ruff

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,11 +16,9 @@ def pytest_addoption(parser: pytest.Parser) -> None:
       parser: The pytest command line parser.
     """
     parser.addoption(
-        "--charm_path",
-        action="store",
-        default=None,
-        help="Path to the charm under test"
+        "--charm_path", action="store", default=None, help="Path to the charm under test"
     )
+
 
 def pytest_configure(config: pytest.Config) -> None:
     """Validate the options provided by the user.

--- a/tests/unit/test_limit_to_first_requester.py
+++ b/tests/unit/test_limit_to_first_requester.py
@@ -85,8 +85,9 @@ ALLOWED_CSRS = [
         application_name="other_app",
         unit_name="other_app/0",
         csr=csr.decode("utf-8"),
-        is_ca=False
-    ) for csr in RESERVED_CSRS
+        is_ca=False,
+    )
+    for csr in RESERVED_CSRS
 ]
 
 REQUIRER_CSRS = [
@@ -95,8 +96,9 @@ REQUIRER_CSRS = [
         application_name="other_app",
         unit_name="other_app/0",
         csr=csr.decode("utf-8"),
-        is_ca=False
-    ) for csr in RESERVED_CSRS
+        is_ca=False,
+    )
+    for csr in RESERVED_CSRS
 ]
 
 OLD_REQUIRER_CSR = RequirerCSR(
@@ -104,12 +106,11 @@ OLD_REQUIRER_CSR = RequirerCSR(
     application_name="my_app",
     unit_name="my_app/0",
     csr=OLD_CSR.decode("utf-8"),
-    is_ca=False
+    is_ca=False,
 )
 
 
 class TestLimitToFirstRequester:
-
     @pytest.mark.parametrize(
         "csr,relation_id,expected",
         [
@@ -136,7 +137,7 @@ class TestLimitToFirstRequester:
                 generate_csr(
                     private_key=PRIVATE_KEY,
                     subject=REQUESTED_SUBJECT,
-                    sans_dns=[choice(RESERVED_DNS)]
+                    sans_dns=[choice(RESERVED_DNS)],
                 ),
                 MY_RELATION_ID,
                 False,
@@ -146,7 +147,7 @@ class TestLimitToFirstRequester:
                 generate_csr(
                     private_key=PRIVATE_KEY,
                     subject=REQUESTED_SUBJECT,
-                    sans_ip=[choice(RESERVED_IPS)]
+                    sans_ip=[choice(RESERVED_IPS)],
                 ),
                 MY_RELATION_ID,
                 False,
@@ -156,7 +157,7 @@ class TestLimitToFirstRequester:
                 generate_csr(
                     private_key=PRIVATE_KEY,
                     subject=REQUESTED_SUBJECT,
-                    sans_oid=[choice(RESERVED_OIDS)]
+                    sans_oid=[choice(RESERVED_OIDS)],
                 ),
                 MY_RELATION_ID,
                 False,
@@ -184,7 +185,7 @@ class TestLimitToFirstRequester:
                 generate_csr(
                     private_key=PRIVATE_KEY,
                     subject=REQUESTED_SUBJECT,
-                    sans_dns=[choice(RESERVED_DNS)]
+                    sans_dns=[choice(RESERVED_DNS)],
                 ),
                 OTHER_RELATION_ID,
                 True,
@@ -194,7 +195,7 @@ class TestLimitToFirstRequester:
                 generate_csr(
                     private_key=PRIVATE_KEY,
                     subject=REQUESTED_SUBJECT,
-                    sans_ip=[choice(RESERVED_IPS)]
+                    sans_ip=[choice(RESERVED_IPS)],
                 ),
                 OTHER_RELATION_ID,
                 True,
@@ -204,7 +205,7 @@ class TestLimitToFirstRequester:
                 generate_csr(
                     private_key=PRIVATE_KEY,
                     subject=REQUESTED_SUBJECT,
-                    sans_oid=[choice(RESERVED_OIDS)]
+                    sans_oid=[choice(RESERVED_OIDS)],
                 ),
                 OTHER_RELATION_ID,
                 True,

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 [tox]
 no_package = True
 skip_missing_interpreters = True
-env_list = lint, static, unit
+env_list = format, lint, static, unit
 min_version = 4.0.0
 
 [vars]
@@ -30,12 +30,14 @@ pass_env =
 description = Apply coding style standards to code
 commands =
     ruff check --fix {[vars]all_path}
+    ruff format {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 commands =
     codespell {tox_root}
     ruff check {[vars]all_path}
+    ruff format --check {[vars]all_path}
 
 [testenv:static]
 description = Run static type checks


### PR DESCRIPTION
Currently, ruff is only configured to check the files for linting errors. This adds ruff formatting to tox checks.

Review notes:

Only tox.ini contains functional changes, the rest are the result of running tox -e format.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
