### PR TITLE
chore: move to common configure hook charm design

### DIFF
--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -318,7 +318,7 @@ LIBAPI = 3
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 18
+LIBPATCH = 19
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -736,16 +736,16 @@ def calculate_expiry_notification_time(
     """
     if provider_recommended_notification_time is not None:
         provider_recommended_notification_time = abs(provider_recommended_notification_time)
-        provider_recommendation_time_delta = (
-            expiry_time - timedelta(hours=provider_recommended_notification_time)
+        provider_recommendation_time_delta = expiry_time - timedelta(
+            hours=provider_recommended_notification_time
         )
         if validity_start_time < provider_recommendation_time_delta:
             return provider_recommendation_time_delta
 
     if requirer_recommended_notification_time is not None:
         requirer_recommended_notification_time = abs(requirer_recommended_notification_time)
-        requirer_recommendation_time_delta = (
-            expiry_time - timedelta(hours=requirer_recommended_notification_time)
+        requirer_recommendation_time_delta = expiry_time - timedelta(
+            hours=requirer_recommended_notification_time
         )
         if validity_start_time < requirer_recommendation_time_delta:
             return requirer_recommendation_time_delta
@@ -1449,7 +1449,9 @@ class TLSCertificatesProvidesV3(Object):
         Returns:
             None
         """
-        provider_certificates = self.get_certificates_for_which_no_csr_exists(relation_id=relation_id)
+        provider_certificates = self.get_unsolicited_certificates(
+            relation_id=relation_id
+        )
         for provider_certificate in provider_certificates:
             self.on.certificate_revocation_request.emit(
                 certificate=provider_certificate.certificate,
@@ -1459,19 +1461,21 @@ class TLSCertificatesProvidesV3(Object):
             )
             self.remove_certificate(certificate=provider_certificate.certificate)
 
-    def get_certificates_for_which_no_csr_exists(self, relation_id: Optional[int] = None) -> List[ProviderCertificate]:
+    def get_unsolicited_certificates(
+        self, relation_id: Optional[int] = None
+    ) -> List[ProviderCertificate]:
         """Return provider certificates for which no certificate requests exists.
 
-        Those certificates should be revoked. 
+        Those certificates should be revoked.
         """
-        csrs: List[RequirerCSR] = []
+        unsolicited_certificates: List[ProviderCertificate] = []
         provider_certificates = self.get_provider_certificates(relation_id=relation_id)
         requirer_csrs = self.get_requirer_csrs(relation_id=relation_id)
         list_of_csrs = [csr.csr for csr in requirer_csrs]
         for certificate in provider_certificates:
             if certificate.csr not in list_of_csrs:
-                csrs.append(certificate)
-        return csrs
+                unsolicited_certificates.append(certificate)
+        return unsolicited_certificates
 
     def get_outstanding_certificate_requests(
         self, relation_id: Optional[int] = None
@@ -1889,8 +1893,7 @@ class TLSCertificatesRequiresV3(Object):
                             "Removing secret with label %s",
                             f"{LIBID}-{csr_in_sha256_hex}",
                         )
-                        secret = self.model.get_secret(
-                            label=f"{LIBID}-{csr_in_sha256_hex}")
+                        secret = self.model.get_secret(label=f"{LIBID}-{csr_in_sha256_hex}")
                         secret.remove_all_revisions()
                     self.on.certificate_invalidated.emit(
                         reason="revoked",

--- a/src/charm.py
+++ b/src/charm.py
@@ -325,9 +325,13 @@ class TLSConstraintsCharm(CharmBase):
         Goes through all the outstanding revocation requests and
         forwards them to the provider.
         """
-        provider_certificates = self.certificates_requirers.get_certificates_for_which_no_csr_exists()
+        provider_certificates = (
+            self.certificates_requirers.get_certificates_for_which_no_csr_exists()
+        )
         for provider_certificate in provider_certificates:
-            self.certificates_provider.request_certificate_revocation(provider_certificate.csr.encode())
+            self.certificates_provider.request_certificate_revocation(
+                provider_certificate.csr.encode()
+            )
 
     def _sync_available_certificates(self):
         """Handle certificate available.

--- a/src/charm.py
+++ b/src/charm.py
@@ -325,9 +325,7 @@ class TLSConstraintsCharm(CharmBase):
         Goes through all the outstanding revocation requests and
         forwards them to the provider.
         """
-        provider_certificates = (
-            self.certificates_requirers.get_certificates_for_which_no_csr_exists()
-        )
+        provider_certificates = self.certificates_requirers.get_unsolicited_certificates()
         for provider_certificate in provider_certificates:
             self.certificates_provider.request_certificate_revocation(
                 provider_certificate.csr.encode()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -52,8 +52,8 @@ class TestCharm:
         f"{TLS_LIB_PATH}.TLSCertificatesProvidesV3.get_requirer_csrs"
     )
 
-    patcher_tls_provides_get_certificates_for_which_no_csr_exists = patch(
-        f"{TLS_LIB_PATH}.TLSCertificatesProvidesV3.get_certificates_for_which_no_csr_exists"
+    patcher_tls_provides_get_unsolicited_certificates = patch(
+        f"{TLS_LIB_PATH}.TLSCertificatesProvidesV3.get_unsolicited_certificates"
     )
     patcher_tls_provides_set_relation_certificate = patch(
         f"{TLS_LIB_PATH}.TLSCertificatesProvidesV3.set_relation_certificate"
@@ -94,8 +94,8 @@ class TestCharm:
         self.mock_tls_provides_get_requirer_csrs = (
             self.patcher_tls_provides_get_requirer_csrs.start()
         )
-        self.mock_tls_provides_get_certificates_for_which_no_csr_exists = (
-            self.patcher_tls_provides_get_certificates_for_which_no_csr_exists.start()
+        self.mock_tls_provides_get_unsolicited_certificates = (
+            self.patcher_tls_provides_get_unsolicited_certificates.start()
         )
         self.mock_tls_provides_set_relation_certificate = (
             self.patcher_tls_provides_set_relation_certificate.start()
@@ -146,7 +146,7 @@ class TestCharm:
     def test_given_certificate_for_which_no_csr_exists_when_configure_then_revocation_is_forwarded_to_provider(  # noqa: E501
         self,
     ) -> None:
-        self.mock_tls_provides_get_certificates_for_which_no_csr_exists.return_value = [
+        self.mock_tls_provides_get_unsolicited_certificates.return_value = [
             ProviderCertificate(
                 relation_id=1,
                 application_name="certificates-provider",


### PR DESCRIPTION
# Description

Here we move to the common `configure` hook charm design. On a regular basis, the charm will look at its state and sync the actual world for it to match expectations.

This PR depends on this library PR being merged first:
- https://github.com/canonical/tls-certificates-interface/pull/236

## Rationale

1. Standardisation with other TLS owned charms
2. Preparing for the tls lib v4. TLS providers now use getters instead of depending on charm events.
3. Preparing for switching to scenario which does not support custom events with attributes

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
