### PR TITLE
chore: adapt integration tests to new tls requirer action output

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -107,9 +107,7 @@ async def test_given_tls_requirer1_is_deployed_and_related_then_certificate_is_c
         timeout=1000,
     )
     action_output = await run_get_certificate_action(ops_test, TLS_REQUIRER1)
-    assert action_output["certificate"] is not None
-    assert action_output["ca-certificate"] is not None
-    assert action_output["csr"] is not None
+    assert action_output.get("certificates") is not None
 
 
 async def test_given_tls_requirer2_is_deployed_and_related_then_certificate_is_created_passed_correctly_and_different(  # noqa: E501


### PR DESCRIPTION
# Description

The integration tests are currently failing on main because of a change in the TLS requirer action output. Here we adapt the integration tests to use the new output format.


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
