### PR TITLE
build: Enable pyright to check if type hints are missing

### DIFF
--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -526,7 +526,7 @@ class CertificateAvailableEvent(EventBase):
 class CertificateExpiringEvent(EventBase):
     """Charm Event triggered when a TLS certificate is almost expired."""
 
-    def __init__(self, handle, certificate: str, expiry: str):
+    def __init__(self, handle: Handle, certificate: str, expiry: str):
         """CertificateExpiringEvent.
 
         Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,4 @@ skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
 
 [tool.pyright]
 include = ["src/**.py"]
+reportMissingParameterType = true

--- a/src/charm.py
+++ b/src/charm.py
@@ -10,7 +10,7 @@ Certificates are provided by the operator through Juju configs.
 import logging
 import re
 from itertools import chain
-from typing import Literal, Optional, Protocol
+from typing import Any, Literal, Optional, Protocol
 
 from charms.tls_certificates_interface.v3.tls_certificates import (
     RequirerCSR,
@@ -235,7 +235,7 @@ class AllowedFields:
 class TLSConstraintsCharm(CharmBase):
     """Main class to handle Juju events."""
 
-    def __init__(self, *args):
+    def __init__(self, *args: Any):
         """Set up charm integration handlers and observe Juju events."""
         super().__init__(*args)
         self.certificates_provider = TLSCertificatesRequiresV3(

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -27,10 +27,10 @@ RELATION_NAME_TO_TLS_PROVIDER = "certificates-upstream"
 
 
 @pytest.fixture(scope="module", autouse=True)
-async def deploy(ops_test: OpsTest, request):
+async def deploy(ops_test: OpsTest, request: pytest.FixtureRequest):
     """Deploy charm-under-test."""
     assert ops_test.model
-    charm = Path(request.config.getoption("--charm_path")).resolve()
+    charm = Path(str(request.config.getoption("--charm_path"))).resolve()
     await ops_test.model.deploy(
         TLS_PROVIDER_CHARM_NAME,
         application_name=TLS_PROVIDER_CHARM_NAME,

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -40,7 +40,7 @@ class TLSConstraintsFixtures:
     )
 
     @pytest.fixture(autouse=True)
-    def setUp(self, request):
+    def setUp(self, request: pytest.FixtureRequest):
         self.mock_tls_requires_request_certificate_creation = (
             self.patcher_tls_requires_request_certificate_creation.start()
         )

--- a/tests/unit/test_allowed_fields.py
+++ b/tests/unit/test_allowed_fields.py
@@ -70,7 +70,10 @@ class TestAllowedFields:
         ],
     )
     def test_given_allowlist_config_filter_when_invalid_csr_given_then_csr_filtered(
-        self, caplog: pytest.LogCaptureFixture, invalid_field, expected_log_message
+        self,
+        caplog: pytest.LogCaptureFixture,
+        invalid_field: dict[str, str],
+        expected_log_message: str,
     ) -> None:
         rules = {
             "allowed-dns": r"myapp-([0-9]+)?\.mycompany\.com",

--- a/tests/unit/test_limit_to_first_requester.py
+++ b/tests/unit/test_limit_to_first_requester.py
@@ -215,7 +215,7 @@ class TestLimitToFirstRequester:
         ],
     )
     def test_given_previous_requesters_when_evaluate_csr_then_csr_is_allowed_or_denied(
-        self, csr, relation_id, expected
+        self, csr: bytes, relation_id: int, expected: bool
     ):
         filter = LimitToFirstRequester(allowed_csrs=ALLOWED_CSRS)
         assert filter.evaluate(csr, relation_id, REQUIRER_CSRS) is expected
@@ -250,7 +250,7 @@ class TestLimitToFirstRequester:
         ],
     )
     def test_given_previous_requesters_when_evaluate_csr_then_denials_are_logged(
-        self, csr, expected, caplog
+        self, csr: bytes, expected: str, caplog: pytest.LogCaptureFixture
     ):
         filter = LimitToFirstRequester(allowed_csrs=ALLOWED_CSRS)
         filter.evaluate(csr, MY_RELATION_ID, REQUIRER_CSRS)
@@ -258,7 +258,7 @@ class TestLimitToFirstRequester:
         assert ("WARNING", "charm", expected) in logs
 
     def test_given_previous_requesters_when_evaluate_csr_then_approvals_are_not_logged(
-        self, caplog
+        self, caplog: pytest.LogCaptureFixture
     ):
         filter = LimitToFirstRequester(allowed_csrs=[])
         filter.evaluate(CSR, MY_RELATION_ID, [])


### PR DESCRIPTION
This change adds a pyright check to ensure that we add type hints to our code