### PR TITLE
test: Use the 1/stable channel for self-signed-certificates

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -34,7 +34,7 @@ async def deploy(ops_test: OpsTest, request: pytest.FixtureRequest):
     await ops_test.model.deploy(
         TLS_PROVIDER_CHARM_NAME,
         application_name=TLS_PROVIDER_CHARM_NAME,
-        channel="stable",
+        channel="1/stable",
     )
     await ops_test.model.deploy(
         TLS_REQUIRER_CHARM_NAME,


### PR DESCRIPTION
Use the `1/stable` channel. `stable` is no longer a valid option.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
